### PR TITLE
Update puppet-lint dependency

### DIFF
--- a/puppet-lint-fileserver-check.gemspec
+++ b/puppet-lint-fileserver-check.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     A puppet-lint plugin to check if puppet:/// is used instead of file().
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
Fixes #1, based on how similar lint modules do it.