### PR TITLE
allow puppet-lint 2.x and newer

### DIFF
--- a/puppet-lint-fileserver-check.gemspec
+++ b/puppet-lint-fileserver-check.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     A puppet-lint plugin to check if puppet:/// is used instead of file().
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '>= 1.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
Hey @mcanevet !
I recently switched my profiles to `file()` and want to enforce that with a linter plugin. I discovered yours :) Currently it's not possible to install it, because it depends on puppet-lint 1.x. I updates the gemspec to also allow newer versions. In addition I tested this locally and it still passes (with puppet-lint 2.4.2). Could you please merge this and kick of a new release?